### PR TITLE
Add reactive rest endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,21 @@
 # Reactive Spring Playground
 
-This isn't necessarily usable code, I'm just fiddling around with Spring Reactor.
+Playground project for getting familiar with non-blocking backends using Spring Reactor.
+This isn't necessarily usable code, I'm just fiddling around with things a bit get a basic understanding of this stuff.
 
 ## How to run
 
-Most stuff here is unit test code that isn't backed by an actual application.
+A coded quite a few scenarios as JUnit test cases, so feel free to explore `src/test` for examples.
 
-I'd recommend opening in you IDE, and running the different test cases.
+You will also find a few minimalistic rest endpoints returning Fluxes and Monos:
+
+* `http://localhost:8080/flux` - emits a flux upon the `onComplete` event
+* `http://localhost:8080/fluxstream` - emits a flux upon every `onNext` event (cold publisher)
+* `http://localhost:8080/mono` - emits a mono upon the `onComplete` event
+* `http://localhost:8080/functional/flux` - same as `/flux`, but implemented using functional-style routers and handlers
+* `http://localhost:8080/functional/mono` - same as `/mono`, but implemented using functional-style routers and handlers
+
+Run it with `mvn spring-boot:run`.
 
 ## Further reading
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,10 +19,11 @@
 	</properties>
 
 	<dependencies>
-		<dependency>
+		<!-- Will be uncommented for backend integration -->
+		<!--<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb-reactive</artifactId>
-		</dependency>
+		</dependency>-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webflux</artifactId>

--- a/src/main/java/de/maik/reactivespring/boundary/FluxAndMonoController.java
+++ b/src/main/java/de/maik/reactivespring/boundary/FluxAndMonoController.java
@@ -4,6 +4,7 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.time.Duration;
 
@@ -11,7 +12,7 @@ import java.time.Duration;
 public class FluxAndMonoController {
 
     /**
-     * Returns Stream as Integer, browser waits until Flux is complete
+     * Returns Stream as Integer, emits on onComplete() event
      */
     @GetMapping("/flux")
     public Flux<Integer> returnFlux() {
@@ -21,12 +22,21 @@ public class FluxAndMonoController {
     }
 
     /**
-     * Returns as infinite stream (cold publisher, new instance for every client connecting)
+     * Returns as infinite stream (cold publisher, new instance for every client connecting),
+     * emits element for every onNext() event
      */
     @GetMapping(value = "/fluxstream", produces = MediaType.APPLICATION_STREAM_JSON_VALUE)
     public Flux<Long> returnFluxStream() {
         return Flux.interval(Duration.ofSeconds(1))
                 .log();
+    }
+
+    /**
+     * Returns Mono at onComplete()
+     */
+    @GetMapping("/mono")
+    public Mono<Integer> returnMono() {
+        return Mono.just(1).log();
     }
 
 }

--- a/src/main/java/de/maik/reactivespring/boundary/FluxAndMonoController.java
+++ b/src/main/java/de/maik/reactivespring/boundary/FluxAndMonoController.java
@@ -21,12 +21,11 @@ public class FluxAndMonoController {
     }
 
     /**
-     * Returns as stream, emits for every onNext
+     * Returns as infinite stream (cold publisher, new instance for every client connecting)
      */
     @GetMapping(value = "/fluxstream", produces = MediaType.APPLICATION_STREAM_JSON_VALUE)
-    public Flux<Integer> returnFluxStream() {
-        return Flux.just(1, 2, 3, 4)
-                .delayElements(Duration.ofSeconds(1))
+    public Flux<Long> returnFluxStream() {
+        return Flux.interval(Duration.ofSeconds(1))
                 .log();
     }
 

--- a/src/main/java/de/maik/reactivespring/boundary/FluxAndMonoController.java
+++ b/src/main/java/de/maik/reactivespring/boundary/FluxAndMonoController.java
@@ -1,0 +1,33 @@
+package de.maik.reactivespring.boundary;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+import java.time.Duration;
+
+@RestController
+public class FluxAndMonoController {
+
+    /**
+     * Returns Stream as Integer, browser waits until Flux is complete
+     */
+    @GetMapping("/flux")
+    public Flux<Integer> returnFlux() {
+        return Flux.just(1, 2, 3, 4)
+                .delayElements(Duration.ofSeconds(1))
+                .log();
+    }
+
+    /**
+     * Returns as stream, emits for every onNext
+     */
+    @GetMapping(value = "/fluxstream", produces = MediaType.APPLICATION_STREAM_JSON_VALUE)
+    public Flux<Integer> returnFluxStream() {
+        return Flux.just(1, 2, 3, 4)
+                .delayElements(Duration.ofSeconds(1))
+                .log();
+    }
+
+}

--- a/src/main/java/de/maik/reactivespring/boundary/handler/SampleHandler.java
+++ b/src/main/java/de/maik/reactivespring/boundary/handler/SampleHandler.java
@@ -1,0 +1,32 @@
+package de.maik.reactivespring.boundary.handler;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Component
+public class SampleHandler {
+
+    /**
+     * Handler Method that sends a Flux of 4 digits
+     * enclosed in a Mono of ServerResponse
+     */
+    public Mono<ServerResponse> flux(ServerRequest request) {
+        return ServerResponse.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Flux.just(1, 2, 3, 4).log(), Integer.class);
+    }
+
+    /**
+     * Handler Method that sends a Mono of a digit
+     * enclosed in a Mono of ServerResponse
+     */
+    public Mono<ServerResponse> mono(ServerRequest request) {
+        return ServerResponse.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Mono.just(1).log(), Integer.class);
+    }
+}

--- a/src/main/java/de/maik/reactivespring/boundary/router/RouterConfig.java
+++ b/src/main/java/de/maik/reactivespring/boundary/router/RouterConfig.java
@@ -1,0 +1,30 @@
+package de.maik.reactivespring.boundary.router;
+
+import de.maik.reactivespring.boundary.handler.SampleHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
+import static org.springframework.web.reactive.function.server.RequestPredicates.accept;
+
+/**
+ * Maps an incoming request to an appropriate handler
+ */
+@Configuration
+public class RouterConfig {
+
+    private static final String FLUX_URI = "/functional/flux";
+    private static final String MONO_URI = "/functional/mono";
+
+    @Bean
+    public RouterFunction<ServerResponse> route(SampleHandler handler) {
+        return RouterFunctions
+                .route(GET(FLUX_URI).and(accept(MediaType.APPLICATION_JSON)), handler::flux)
+                .andRoute(GET(MONO_URI).and(accept(MediaType.APPLICATION_JSON)), handler::mono);
+    }
+
+}

--- a/src/test/java/de/maik/reactivespring/boundary/FluxAndMonoControllerTest.java
+++ b/src/test/java/de/maik/reactivespring/boundary/FluxAndMonoControllerTest.java
@@ -22,6 +22,8 @@ class FluxAndMonoControllerTest {
 
     private static final String FLUX_ENDPOINT_URI = "/flux";
     private static final String FLUX_STREAM_ENDPOINT_URI = "/fluxstream";
+    private static final String MONO_ENDPOINT_URI = "/mono";
+
     @Autowired
     WebTestClient webTestClient; // equivalent to TestRestTemplate from SpringMVC
 
@@ -108,6 +110,16 @@ class FluxAndMonoControllerTest {
                 .expectNext(3L)
                 .thenCancel()
                 .verify();
+    }
+
+    @Test
+    void canCallAndConsumeMono() {
+        webTestClient.get().uri(MONO_ENDPOINT_URI)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(Integer.class)
+                .consumeWith(response -> assertThat(response.getResponseBody()).isEqualTo(1));
     }
 
 }

--- a/src/test/java/de/maik/reactivespring/boundary/FluxAndMonoControllerTest.java
+++ b/src/test/java/de/maik/reactivespring/boundary/FluxAndMonoControllerTest.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@WebFluxTest
+@WebFluxTest // Will only scan for rest controllers and web components
 @ExtendWith(SpringExtension.class)
 class FluxAndMonoControllerTest {
 

--- a/src/test/java/de/maik/reactivespring/boundary/FluxAndMonoControllerTest.java
+++ b/src/test/java/de/maik/reactivespring/boundary/FluxAndMonoControllerTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class FluxAndMonoControllerTest {
 
     private static final String FLUX_ENDPOINT_URI = "/flux";
+    private static final String FLUX_STREAM_ENDPOINT_URI = "/fluxstream";
     @Autowired
     WebTestClient webTestClient; // equivalent to TestRestTemplate from SpringMVC
 
@@ -87,6 +88,26 @@ class FluxAndMonoControllerTest {
                 .expectStatus().isOk()
                 .expectBodyList(Integer.class)
                 .consumeWith(response -> assertThat(response.getResponseBody()).isEqualTo(expectedResultList));
+    }
+
+    @Test
+    void canCallAndConsumeFirst4ElementsFromInfiniteFluxStream() {
+        Flux<Long> longFluxStream = webTestClient
+                .get()
+                .uri(FLUX_STREAM_ENDPOINT_URI)
+                .accept(MediaType.APPLICATION_STREAM_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .returnResult(Long.class)
+                .getResponseBody();
+
+        StepVerifier.create(longFluxStream)
+                .expectNext(0L)
+                .expectNext(1L)
+                .expectNext(2L)
+                .expectNext(3L)
+                .thenCancel()
+                .verify();
     }
 
 }

--- a/src/test/java/de/maik/reactivespring/boundary/FluxAndMonoControllerTest.java
+++ b/src/test/java/de/maik/reactivespring/boundary/FluxAndMonoControllerTest.java
@@ -1,0 +1,92 @@
+package de.maik.reactivespring.boundary;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WebFluxTest
+@ExtendWith(SpringExtension.class)
+class FluxAndMonoControllerTest {
+
+    private static final String FLUX_ENDPOINT_URI = "/flux";
+    @Autowired
+    WebTestClient webTestClient; // equivalent to TestRestTemplate from SpringMVC
+
+    @Test
+    void canCallAndConsumeFluxEndpointValuesAs1234() {
+        Flux<Integer> integerFlux = webTestClient
+                .get()
+                .uri(FLUX_ENDPOINT_URI)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .returnResult(Integer.class)
+                .getResponseBody();
+
+        // Evaluates concrete values
+        StepVerifier.create(integerFlux)
+                .expectSubscription()
+                .expectNext(1)
+                .expectNext(2)
+                .expectNext(3)
+                .expectNext(4)
+                .verifyComplete();
+    }
+
+    @Test
+    void canCallAndConsumeFluxEndpointAsListOf4IntegerValues() {
+        webTestClient
+                .get()
+                .uri(FLUX_ENDPOINT_URI)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectHeader().contentType(MediaType.APPLICATION_JSON)
+                .expectBodyList(Integer.class).hasSize(4); // We don't care about the actual values, 4 Ints is enough here
+    }
+
+    @Test
+    void canCallAndConsumeFluxEndpointValuesAsListOfIntegers() {
+        List expectedResultList = Arrays.asList(1, 2, 3, 4);
+
+        EntityExchangeResult<List<Integer>> result = webTestClient
+                .get()
+                .uri(FLUX_ENDPOINT_URI)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(Integer.class)
+                .returnResult();
+
+        // Compare as lists
+        assertThat(result.getResponseBody()).isEqualTo(expectedResultList);
+    }
+
+    @Test
+    void canCallAndConsumeFluxEndpointValuesUsingConsumer() {
+        List expectedResultList = Arrays.asList(1, 2, 3, 4);
+
+        webTestClient
+                .get()
+                .uri(FLUX_ENDPOINT_URI)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(Integer.class)
+                .consumeWith(response -> assertThat(response.getResponseBody()).isEqualTo(expectedResultList));
+    }
+
+}

--- a/src/test/java/de/maik/reactivespring/boundary/handler/SampleHandlerTest.java
+++ b/src/test/java/de/maik/reactivespring/boundary/handler/SampleHandlerTest.java
@@ -1,0 +1,63 @@
+package de.maik.reactivespring.boundary.handler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Flux;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Basically the same test cases as standard rest controller tests as the behavior is
+ * the same - the implementation is different however using the functional approach,
+ * and we thus need a full fledged application context in order for the tests to work
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest // Will fire up the whole application context
+@AutoConfigureWebTestClient
+class SampleHandlerTest {
+
+    private static final String FLUX_ENDPOINT_URI = "/functional/flux";
+    private static final String MONO_ENDPOINT_URI = "/functional/mono";
+    @Autowired
+    WebTestClient webTestClient;
+
+    @Test
+    void canCallAndConsumeFluxEndpointValuesAs1234() {
+        Flux<Integer> integerFlux = webTestClient
+                .get()
+                .uri(FLUX_ENDPOINT_URI)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .returnResult(Integer.class)
+                .getResponseBody();
+
+        // Evaluates concrete values
+        StepVerifier.create(integerFlux)
+                .expectSubscription()
+                .expectNext(1)
+                .expectNext(2)
+                .expectNext(3)
+                .expectNext(4)
+                .verifyComplete();
+    }
+
+    @Test
+    void canCallAndConsumeMono() {
+        webTestClient.get().uri(MONO_ENDPOINT_URI)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(Integer.class)
+                .consumeWith(response -> assertThat(response.getResponseBody()).isEqualTo(1));
+    }
+
+
+}


### PR DESCRIPTION
Add concrete examples for classic-style rest endpoints as well as functional-style rest configs and handlers.